### PR TITLE
Improve deadlock deps fix

### DIFF
--- a/packages/playground/ssr-react/__tests__/ssr-react.spec.ts
+++ b/packages/playground/ssr-react/__tests__/ssr-react.spec.ts
@@ -1,4 +1,4 @@
-import { editFile, getColor, isBuild, untilUpdated } from '../../testUtils'
+import { editFile, untilUpdated } from '../../testUtils'
 import { port } from './serve'
 import fetch from 'node-fetch'
 
@@ -45,4 +45,11 @@ test('client navigation', async () => {
     code.replace('<h1>About', '<h1>changed')
   )
   await untilUpdated(() => page.textContent('h1'), 'changed')
+})
+
+test(`circular dependecies modules doesn't throw`, async () => {
+  await page.goto(url)
+  expect(await page.textContent('.circ-dep-init')).toMatch(
+    'circ-dep-init-a circ-dep-init-b'
+  )
 })

--- a/packages/playground/ssr-react/src/circular-dep-init/README.md
+++ b/packages/playground/ssr-react/src/circular-dep-init/README.md
@@ -1,0 +1,1 @@
+This test aim to find out wherever the modules with circular dependencies are correctly initialized

--- a/packages/playground/ssr-react/src/circular-dep-init/circular-dep-init.js
+++ b/packages/playground/ssr-react/src/circular-dep-init/circular-dep-init.js
@@ -1,0 +1,2 @@
+export * from './module-a'
+export { getValueAB } from './module-b'

--- a/packages/playground/ssr-react/src/circular-dep-init/module-a.js
+++ b/packages/playground/ssr-react/src/circular-dep-init/module-a.js
@@ -1,0 +1,1 @@
+export const valueA = 'circ-dep-init-a'

--- a/packages/playground/ssr-react/src/circular-dep-init/module-b.js
+++ b/packages/playground/ssr-react/src/circular-dep-init/module-b.js
@@ -1,0 +1,8 @@
+import { valueA } from './circular-dep-init'
+
+export const valueB = 'circ-dep-init-b'
+export const valueAB = valueA.concat(` ${valueB}`)
+
+export function getValueAB() {
+  return valueAB
+}

--- a/packages/playground/ssr-react/src/forked-deadlock/README.md
+++ b/packages/playground/ssr-react/src/forked-deadlock/README.md
@@ -1,0 +1,45 @@
+This test aim to check for a particular type of circular dependency that causes tricky deadlocks, **deadlocks with forked imports stack**
+
+```
+A -> B means: B is imported by A and B has A in its stack
+A ... B means: A is waiting for B to ssrLoadModule()
+
+H -> X ... Y
+H -> X -> Y ... B
+H -> A ... B
+H -> A -> B ... X
+```
+
+### Forked deadlock description:
+```
+[X] is waiting for [Y] to resolve
+ ↑                  ↳ is waiting for [A] to resolve
+ │                                    ↳ is waiting for [B] to resolve
+ │                                                      ↳ is waiting for [X] to resolve
+ └────────────────────────────────────────────────────────────────────────┘
+```
+
+This may seems a traditional deadlock, but the thing that makes this special is the import stack of each module:
+```
+[X] stack:
+	[H]
+```
+```
+[Y] stack:
+	[X]
+	[H]
+```
+```
+[A] stack:
+	[H]
+```
+```
+[B] stack:
+	[A]
+	[H]
+```
+Even if `[X]` is imported by `[B]`, `[B]` is not in `[X]`'s stack because it's imported by `[H]` in first place then it's stack is only composed by `[H]`. `[H]` **forks** the imports **stack** and this make hard to be found.
+
+### Fix description
+Vite, when imports `[X]`, should check whether `[X]` is already pending and if it is, it must check that, when it was imported in first place, the stack of `[X]` doesn't have any module in common with the current module; in this case `[B]` has the module `[H]` is common with `[X]` and i can assume that a deadlock is going to happen.
+

--- a/packages/playground/ssr-react/src/forked-deadlock/common-module.js
+++ b/packages/playground/ssr-react/src/forked-deadlock/common-module.js
@@ -1,0 +1,10 @@
+import { stuckModuleExport } from './stuck-module'
+import { deadlockfuseModuleExport } from './deadlock-fuse-module'
+
+/**
+ * module H
+ */
+export function commonModuleExport() {
+  stuckModuleExport()
+  deadlockfuseModuleExport()
+}

--- a/packages/playground/ssr-react/src/forked-deadlock/deadlock-fuse-module.js
+++ b/packages/playground/ssr-react/src/forked-deadlock/deadlock-fuse-module.js
@@ -1,0 +1,8 @@
+import { fuseStuckBridgeModuleExport } from './fuse-stuck-bridge-module'
+
+/**
+ * module A
+ */
+export function deadlockfuseModuleExport() {
+  fuseStuckBridgeModuleExport()
+}

--- a/packages/playground/ssr-react/src/forked-deadlock/fuse-stuck-bridge-module.js
+++ b/packages/playground/ssr-react/src/forked-deadlock/fuse-stuck-bridge-module.js
@@ -1,0 +1,8 @@
+import { stuckModuleExport } from './stuck-module'
+
+/**
+ * module C
+ */
+export function fuseStuckBridgeModuleExport() {
+  stuckModuleExport()
+}

--- a/packages/playground/ssr-react/src/forked-deadlock/middle-module.js
+++ b/packages/playground/ssr-react/src/forked-deadlock/middle-module.js
@@ -1,0 +1,8 @@
+import { deadlockfuseModuleExport } from './deadlock-fuse-module'
+
+/**
+ * module Y
+ */
+export function middleModuleExport() {
+  void deadlockfuseModuleExport
+}

--- a/packages/playground/ssr-react/src/forked-deadlock/stuck-module.js
+++ b/packages/playground/ssr-react/src/forked-deadlock/stuck-module.js
@@ -1,0 +1,8 @@
+import { middleModuleExport } from './middle-module'
+
+/**
+ * module X
+ */
+export function stuckModuleExport() {
+  middleModuleExport()
+}

--- a/packages/playground/ssr-react/src/pages/Home.jsx
+++ b/packages/playground/ssr-react/src/pages/Home.jsx
@@ -1,12 +1,17 @@
 import { addAndMultiply } from '../add'
 import { multiplyAndAdd } from '../multiply'
+import { commonModuleExport } from '../forked-deadlock/common-module'
+import { getValueAB } from '../circular-dep-init/circular-dep-init'
 
 export default function Home() {
+  commonModuleExport()
+
   return (
     <>
       <h1>Home</h1>
       <div>{addAndMultiply(1, 2, 3)}</div>
       <div>{multiplyAndAdd(1, 2, 3)}</div>
+      <div className="circ-dep-init">{getValueAB()}</div>
     </>
   )
 }

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -17,15 +17,40 @@ interface SSRContext {
 }
 
 type SSRModule = Record<string, any>
+type ImportsStack = string[]
 
 const pendingModules = new Map<string, Promise<SSRModule>>()
 const pendingImports = new Map<string, Set<string>>()
+const erroredModules = new Map<string, ImportsStack>()
 
-export async function ssrLoadModule(
+export { ssrLoadModuleAndRetryFailedModules as ssrLoadModule }
+async function ssrLoadModuleAndRetryFailedModules(
   url: string,
   server: ViteDevServer,
   context: SSRContext = { global },
-  urlStack: string[] = []
+  urlStack: ImportsStack = []
+): Promise<SSRModule> {
+  const mod = await ssrLoadModule(url, server, context, urlStack)
+  if (erroredModules.size) {
+    await retryFailedModules(server, context)
+  }
+  return mod
+}
+
+async function retryFailedModules(
+  server: ViteDevServer,
+  context: SSRContext = { global }
+) {
+  for (const [modToRetryUrl, modToRetryUrlStack] of erroredModules.entries()) {
+    await ssrLoadModule(modToRetryUrl, server, context, modToRetryUrlStack)
+  }
+}
+
+async function ssrLoadModule(
+  url: string,
+  server: ViteDevServer,
+  context: SSRContext = { global },
+  urlStack: ImportsStack = []
 ): Promise<SSRModule> {
   url = unwrapId(url)
 
@@ -47,26 +72,32 @@ export async function ssrLoadModule(
 
   const modulePromise = instantiateModule(url, server, context, urlStack)
   pendingModules.set(url, modulePromise)
-  modulePromise
-    .catch(() => {})
-    .then(() => {
-      pendingModules.delete(url)
-      pendingImports.delete(url)
-    })
-  return modulePromise
+
+  const result = modulePromise.then(([mod, err]) => {
+    if (err) {
+      erroredModules.set(url, urlStack)
+    } else {
+      erroredModules.delete(url)
+    }
+    pendingModules.delete(url)
+    pendingImports.delete(url)
+    return mod
+  })
+
+  return result
 }
 
 async function instantiateModule(
   url: string,
   server: ViteDevServer,
   context: SSRContext = { global },
-  urlStack: string[] = []
-): Promise<SSRModule> {
+  urlStack: ImportsStack = []
+): Promise<[SSRModule, Error?]> {
   const { moduleGraph } = server
   const mod = await moduleGraph.ensureEntryFromUrl(url)
 
-  if (mod.ssrModule) {
-    return mod.ssrModule
+  if (mod.ssrModule && !erroredModules.has(url)) {
+    return [mod.ssrModule]
   }
 
   const result =
@@ -79,14 +110,16 @@ async function instantiateModule(
 
   urlStack = urlStack.concat(url)
 
-  const ssrModule = {
-    [Symbol.toStringTag]: 'Module'
-  }
-  Object.defineProperty(ssrModule, '__esModule', { value: true })
+  if (!mod.ssrModule) {
+    const ssrModule = {
+      [Symbol.toStringTag]: 'Module'
+    }
+    Object.defineProperty(ssrModule, '__esModule', { value: true })
 
-  // Tolerate circular imports by ensuring the module can be
-  // referenced before it's been instantiated.
-  mod.ssrModule = ssrModule
+    // Tolerate circular imports by ensuring the module can be
+    // referenced before it's been instantiated.
+    mod.ssrModule = ssrModule
+  }
 
   const isExternal = (dep: string) => dep[0] !== '.' && dep[0] !== '/'
 
@@ -137,7 +170,7 @@ async function instantiateModule(
   function ssrExportAll(sourceModule: any) {
     for (const key in sourceModule) {
       if (key !== 'default') {
-        Object.defineProperty(ssrModule, key, {
+        Object.defineProperty(mod.ssrModule, key, {
           enumerable: true,
           configurable: true,
           get() {
@@ -159,7 +192,7 @@ async function instantiateModule(
       result.code + `\n//# sourceURL=${mod.url}`
     )(
       context.global,
-      ssrModule,
+      mod.ssrModule,
       ssrImportMeta,
       ssrImport,
       ssrDynamicImport,
@@ -174,10 +207,11 @@ async function instantiateModule(
         clear: server.config.clearScreen
       }
     )
-    throw e
+
+    return [mod.ssrModule, e]
   }
 
-  return Object.freeze(ssrModule)
+  return [Object.freeze(mod.ssrModule)]
 }
 
 function nodeRequire(id: string, importer: string | null, root: string) {


### PR DESCRIPTION
Your PR works well with "forked circular dependencies" but it fails when in a circular dependency a module need a value from another module in its stack es:

`A --> B --> C --> A`

where `C` needs a value from `A` in order to be initialized, otherwise it throws.

i've made a test for this case: https://github.com/raythurnevoid/vite/tree/improve_deadlock_deps_fix/packages/playground/ssr-react/src/circular-dep-init

Actually the fix is still not perfect since it works only when a module actually throws on initialization but this doesn't always happend. This can now be optimized using pendingImports.